### PR TITLE
Modify Dockerfile to auto-detect architecture

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,7 +28,8 @@ RUN chsh -s /usr/bin/zsh root
 
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        curl -fL https://github.com/coursier/coursier/releases/latest/download/cs-x86_64-pc-linux.gz | gzip -d > cs && chmod +x cs && ./cs setup -y && rm -f cs; \
+        coursier_url="https://github.com/coursier/coursier/releases/latest/download/cs-x86_64-pc-linux.gz"; \
     else \
-        curl -fL https://github.com/VirtusLab/coursier-m1/releases/latest/download/cs-aarch64-pc-linux.gz | gzip -d > cs && chmod +x cs && ./cs setup -y && rm -f cs; \
-    fi
+        coursier_url="https://github.com/VirtusLab/coursier-m1/releases/latest/download/cs-aarch64-pc-linux.gz"; \
+    fi && \
+    curl -fL ${coursier_url} | gzip -d > cs && chmod +x cs && ./cs setup -y && rm -f cs

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,8 +28,11 @@ RUN chsh -s /usr/bin/zsh root
 
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        # x64_64
         coursier_url="https://github.com/coursier/coursier/releases/latest/download/cs-x86_64-pc-linux.gz"; \
     else \
+        # arm64
         coursier_url="https://github.com/VirtusLab/coursier-m1/releases/latest/download/cs-aarch64-pc-linux.gz"; \
     fi && \
+    # install coursier for the appropriate CPU architecture
     curl -fL ${coursier_url} | gzip -d > cs && chmod +x cs && ./cs setup -y && rm -f cs

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,10 +26,9 @@ COPY .zshrc /root/.zshrc
 #use zsh as main shell
 RUN chsh -s /usr/bin/zsh root
 
-# install scala -> uncomment one of the following lines
-
-# x86_64
-# RUN curl -fL https://github.com/coursier/coursier/releases/latest/download/cs-x86_64-pc-linux.gz | gzip -d > cs && chmod +x cs && ./cs setup -y && rm -f cs
-
-# For ARM64
-# RUN curl -fL https://github.com/VirtusLab/coursier-m1/releases/latest/download/cs-aarch64-pc-linux.gz | gzip -d > cs && chmod +x cs && ./cs setup -y && rm -f cs
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        curl -fL https://github.com/coursier/coursier/releases/latest/download/cs-x86_64-pc-linux.gz | gzip -d > cs && chmod +x cs && ./cs setup -y && rm -f cs; \
+    else \
+        curl -fL https://github.com/VirtusLab/coursier-m1/releases/latest/download/cs-aarch64-pc-linux.gz | gzip -d > cs && chmod +x cs && ./cs setup -y && rm -f cs; \
+    fi

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ First, you must clone our template repository. You can do this by running the fo
 ```bash
 git clone https://github.com/datasys-lab/KTH-ID2203-assignments.git
 ```
-After cloning the repository go to `.devcontainer/Dockerfile` and uncomment one of the *coursier* installations at the bottom of the file depending on which architecture you are running.
 
 Now you should open the project in VSCode. At this moment a notification should appear in the bottom right corner of your screen asking you to reopen the project in a container. Click on the `Reopen in Container` button.
 ![reopen-in-container-vscode](https://github.com/user-attachments/assets/e1762a5b-7366-4e77-aff4-bc3ecb0a5d5f)


### PR DESCRIPTION
Using the Docker BuildKit feature to automatically set the argument for `TARGETARCH` and others, described in [Multi-platform | Docker Docs](https://docs.docker.com/build/building/multi-platform/#build-multi-platform-images), automatically select the appropriate architecture for building the devcontainer image, and install the correct coursier release.